### PR TITLE
find the correct urls in header links

### DIFF
--- a/code/script/ts/header.ts
+++ b/code/script/ts/header.ts
@@ -92,9 +92,8 @@ const getHeaderMenu = () => {
                         console.error('unable to add header menu');
                     }
 
-                    for (let i in apimenus) {
+                    for (let i = 0; i < apimenus.length; i++) {
                         let submenu = apimenus[i];
-                        let id = submenu.Values.toString().replace(" ", "");
 
                         // Using createelement to enable attachment of eventlistener
                         let buttonname = submenu.Values;
@@ -116,7 +115,16 @@ const getHeaderMenu = () => {
 
                             const anchorItem = document.createElement('a');
                             anchorItem.classList.add('header-mega-link-element');
-                            anchorItem.href = 'https://artsdatabanken.no' + item.Url;
+
+                            if (i == 0) {
+                                anchorItem.href = 'https://artsdatabanken.no' + item.Url;
+                            } else {
+                                if (item.Records[0]?.Values[0]?.indexOf('artsdatabanken.no') != -1) {
+                                    anchorItem.href = item.Records[0].Values[0];
+                                } else {
+                                    anchorItem.href = item.Records[1].Values[0];
+                                }
+                            }
 
                             const anchorItemContent = document.createElement('div');
                             anchorItemContent.classList.add('header-mega-link-text');


### PR DESCRIPTION
Url-er i header-menyen ble feil for de som ligger under "Våre tjenester". Disse er nå rettet opp